### PR TITLE
Set sessionID and TokenID before call method

### DIFF
--- a/cmd/hinfo/main.go
+++ b/cmd/hinfo/main.go
@@ -31,6 +31,15 @@ func run(ctx context.Context, endpoint string, debug bool) error {
 	}
 	// create client
 	cl := hilink.NewClient(opts...)
+	// retrieve session id
+	sessID, tokID, err := cl.NewSessionAndTokenID(ctx)
+	if err != nil {
+		return err
+	}
+	// set session id
+	if err := cl.SetSessionAndTokenID(sessID, tokID); err != nil {
+		return err
+	}
 	// get device info
 	d, err := cl.DeviceInfo(ctx)
 	if err != nil {

--- a/cmd/hlcli/main.go
+++ b/cmd/hlcli/main.go
@@ -80,6 +80,15 @@ func run(ctx context.Context) error {
 	}
 	// create client
 	cl := hilink.NewClient(opts...)
+	// retrieve session id
+	sessID, tokID, err := cl.NewSessionAndTokenID(ctx)
+	if err != nil {
+		return err
+	}
+	// set session id
+	if err := cl.SetSessionAndTokenID(sessID, tokID); err != nil {
+		return err
+	}
 	// push client onto params and execute
 	in[0] = reflect.ValueOf(cl)
 	in[1] = reflect.ValueOf(ctx)


### PR DESCRIPTION
My device is:
  "Classify": "hilink",
  "DeviceName": "E3372",
  "HardwareVersion": "CL1E3372SM",
  "Iccid": "8970199201121107156F",
  "Imei": "867012022281593",
  "Imsi": "250992235554538",
  "MacAddress1": "BA:AB:BE:34:00:00",
  "MacAddress2": "",
  "Msisdn": "",
  "ProductFamily": "LTE",
  "SerialNumber": "L8FBY15612000792",
  "SoftwareVersion": "22.300.09.00.00",
  "WebUIVersion": "17.100.13.01.03-Mod1.10",
  "supportmode": "LTE|WCDMA|GSM",
  "workmode": "LTE"

hinfo and hlcli not working correctly if not set sessionID and TokenID.